### PR TITLE
Added -p 8000:8000 to jupyterhub Docker quick start command.

### DIFF
--- a/docs/source/quickstart-docker.rst
+++ b/docs/source/quickstart-docker.rst
@@ -25,7 +25,7 @@ Starting JupyterHub with docker
 
 The JupyterHub docker image can be started with the following command::
 
-    docker run -d --name jupyterhub jupyterhub/jupyterhub jupyterhub
+    docker run -d -p 8000:8000 --name jupyterhub jupyterhub/jupyterhub jupyterhub
 
 This command will create a container named ``jupyterhub`` that you can
 **stop and resume** with ``docker stop/start``.


### PR DESCRIPTION
If port 8000 isn't published, the quick-start command to launch a JupyterHub Docker image isn't very useful.  Adding this means it can be accesses on http://localhost:8000 .